### PR TITLE
added noSwipping arg to f7Slider

### DIFF
--- a/R/f7-inputs.R
+++ b/R/f7-inputs.R
@@ -1095,6 +1095,7 @@ f7Password <- function(inputId, label, value = "", placeholder = NULL) {
 #' @param labels Enables additional label around range slider knob. List of 2 \link{f7Icon}
 #' expected.
 #' @param color See \link{getF7Colors} for valid colors.
+#' @param noSwipping Prevent swiping when slider is manipulated in a \code{\link{f7TabLayout}}.
 #'
 #' @note labels option only works when vertical is FALSE!
 #'
@@ -1171,7 +1172,8 @@ f7Password <- function(inputId, label, value = "", placeholder = NULL) {
 #'
 f7Slider <- function(inputId, label, min, max, value, step = 1, scale = FALSE,
                      scaleSteps = 5, scaleSubSteps = 0, vertical = FALSE,
-                     verticalReversed = FALSE, labels = NULL, color = NULL) {
+                     verticalReversed = FALSE, labels = NULL, color = NULL,
+                     noSwipping = TRUE) {
 
   if (!is.null(labels)) {
     if (length(labels) < 2) stop("labels must be a tagList with 2 elements.")
@@ -1179,6 +1181,10 @@ f7Slider <- function(inputId, label, min, max, value, step = 1, scale = FALSE,
 
   sliderCl <- "range-slider"
   if (!is.null(color)) sliderCl <- paste0(sliderCl, " color-", color)
+
+  if (isTRUE(noSwipping)) {
+    sliderCl <- paste(sliderCl, "swiper-no-swiping")
+  }
 
   sliderProps <- dropNulls(
     list(

--- a/man/f7Slider.Rd
+++ b/man/f7Slider.Rd
@@ -17,7 +17,8 @@ f7Slider(
   vertical = FALSE,
   verticalReversed = FALSE,
   labels = NULL,
-  color = NULL
+  color = NULL,
+  noSwipping = TRUE
 )
 }
 \arguments{
@@ -48,6 +49,8 @@ FALSE by default.}
 expected.}
 
 \item{color}{See \link{getF7Colors} for valid colors.}
+
+\item{noSwipping}{Prevent swiping when slider is manipulated in a \code{\link{f7TabLayout}}.}
 }
 \description{
 Create a f7 slider


### PR DESCRIPTION
Hi David,

When setting value of a slider in a swipeable `f7TabLayout` it cause the tab to be swip. This describe here : https://github.com/framework7io/framework7/issues/2603

I added argument `noSwipping` to `f7Slider` to prevent this behavior. Default is `TRUE` because I don't see why this behavior will be wanted, but I put `FALSE` if you prefer to be sure to not introduce unexpected behavior elsewhere.

Here an example with and without : 

```r
library(shiny)
library(shinyMobile)

shiny::shinyApp(
  ui = f7Page(
    title = "My app",
    f7TabLayout(
      navbar = f7Navbar(title = "f7Slider"),
      
      f7Tabs(
        swipeable = TRUE,
        animated = FALSE,
        
        
        f7Tab(
          tabName = "Tab 1",
          
          f7Card(
            
            f7Slider(
              inputId = "obs1",
              label = "Number of observations",
              max = 1000,
              min = 0,
              value = 100,
              scaleSteps = 5,
              scaleSubSteps = 3,
              scale = TRUE,
              color = "orange",
              labels = tagList(
                f7Icon("circle"),
                f7Icon("circle_fill")
              )
            ),
            
            f7Slider(
              inputId = "obs2",
              label = "Number of observations",
              max = 1000,
              min = 0,
              value = 100,
              scaleSteps = 5,
              scaleSubSteps = 3,
              scale = TRUE,
              color = "orange",
              labels = tagList(
                f7Icon("circle"),
                f7Icon("circle_fill")
              ),
              noSwipping = FALSE
            )
            
          )
          
        ),
        
        f7Tab(
          tabName = "Tab 2",
          "Blabla"
        )
        
      )
      
    )
  ),
  
  server = function(input, output) {
    
  }
)
```

Vic

