### PR TITLE
Grid - Columns and Rows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^docs$
 ^cran-comments\.md$
 ^appveyor\.yml$
+test.R

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 inst/doc
 inst/examples/**/rsconnect
 .DS_Store
+test.R

--- a/R/f7Grid.R
+++ b/R/f7Grid.R
@@ -3,6 +3,7 @@
 #' Build a Framework7 row container
 #'
 #' @param ... Row content.
+#' @param resizable Whether to create a resizable row.
 #' @param gap Whether to display gap between columns. TRUE by default.
 #'
 #' @examples
@@ -45,8 +46,17 @@
 #' @author David Granjon, \email{dgranjon@@ymail.com}
 #'
 #' @export
-f7Row <- function(..., gap = TRUE) {
- shiny::tags$div(class = if (gap) "row" else "row no-gap", ...)
+f7Row <- function(..., gap = TRUE, resizable = FALSE) {
+  cl <- "row"
+  if(!gap) cl <- paste(cl, "no-gap")
+  if(resizable) cl <- paste(cl, "resizable")
+
+  row <- shiny::tags$div(class = cl, ...)
+
+  if(resizable)
+    row <- shiny::tagAppendChild(row, shiny::span(class = "resize-handler"))
+
+  return(row)
 }
 
 
@@ -54,7 +64,10 @@ f7Row <- function(..., gap = TRUE) {
 #' Create a Framework7 column container
 #'
 #' Build a Framework7 column container
-#'
+#' 
+#' @param width Width of column, an integer ranging from 0 to 100 giving the width
+#' in percentage.
+#' @param resizable Whether to create a resizable column.
 #' @param ... Column content. The width is automatically handled depending
 #' on the number of columns.
 #'
@@ -64,7 +77,23 @@ f7Row <- function(..., gap = TRUE) {
 #' instead.
 #'
 #' @export
-f7Col <- function(...) shiny::tags$div(class = "col", ...)
+f7Col <- function(..., width = NULL, resizable = FALSE){
+  cl <- "col"
+
+  # width
+  if(!is.null(width))
+    cl <- paste0(col, width)
+
+  # sizable
+  if(resizable) cl <- paste(cl, "resizable")
+
+  col <- shiny::tags$div(class = cl, ...)
+
+  if(resizable)
+    col <- shiny::tagAppendChild(col, shiny::span(class = "resize-handler"))
+
+  return(col)
+}
 
 
 

--- a/R/f7Grid.R
+++ b/R/f7Grid.R
@@ -82,7 +82,7 @@ f7Col <- function(..., width = NULL, resizable = FALSE){
 
   # width
   if(!is.null(width))
-    cl <- paste0(col, width)
+    cl <- paste0(cl, "-", width)
 
   # sizable
   if(resizable) cl <- paste(cl, "resizable")

--- a/R/f7Page.R
+++ b/R/f7Page.R
@@ -8,13 +8,14 @@
 #' @param title Page title.
 #' @param preloader Whether to display a preloader before the app starts.
 #' FALSE by default.
+#' @param manifest Path to manifest.json.
 #' @param loading_duration Preloader duration.
 #'
 #' @author David Granjon, \email{dgranjon@@ymail.com}
 #'
 #' @export
 f7Page <- function(..., init = f7Init(skin = "auto", theme = "light"), title = NULL, preloader = FALSE,
-                   loading_duration = 3){
+                   loading_duration = 3, manifest = "manifest.json"){
 
   shiny::tags$html(
     # Head
@@ -37,7 +38,7 @@ f7Page <- function(..., init = f7Init(skin = "auto", theme = "light"), title = N
       shiny::tags$meta(name = "apple-mobile-web-app-status-bar-style", content = "black-translucent"),
       shiny::tags$link(rel = "apple-touch-icon", href = "icons/apple-touch-icon.png"),
       shiny::tags$link(rel = "icon", href = "icons/favicon.png"),
-      shiny::tags$link(rel = "manifest", href = "manifest.json"),
+      shiny::tags$link(rel = "manifest", href = manifest),
 
       # Splatshscreen for IOS must be in a www folder
       shiny::tags$link(href = "splashscreens/iphone5_splash.png", media = "(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)", rel = "apple-touch-startup-image"),

--- a/man/f7Col.Rd
+++ b/man/f7Col.Rd
@@ -4,11 +4,16 @@
 \alias{f7Col}
 \title{Create a Framework7 column container}
 \usage{
-f7Col(...)
+f7Col(..., width = NULL, resizable = FALSE)
 }
 \arguments{
 \item{...}{Column content. The width is automatically handled depending
 on the number of columns.}
+
+\item{width}{Width of column, an integer ranging from 0 to 100 giving the width
+in percentage.}
+
+\item{resizable}{Whether to create a resizable column.}
 }
 \description{
 Build a Framework7 column container

--- a/man/f7Page.Rd
+++ b/man/f7Page.Rd
@@ -9,7 +9,8 @@ f7Page(
   init = f7Init(skin = "auto", theme = "light"),
   title = NULL,
   preloader = FALSE,
-  loading_duration = 3
+  loading_duration = 3,
+  manifest = "manifest.json"
 )
 }
 \arguments{
@@ -24,6 +25,8 @@ f7Page(
 FALSE by default.}
 
 \item{loading_duration}{Preloader duration.}
+
+\item{manifest}{Path to manifest.json.}
 }
 \description{
 Build a Framework7 page

--- a/man/f7Row.Rd
+++ b/man/f7Row.Rd
@@ -4,12 +4,14 @@
 \alias{f7Row}
 \title{Create a Framework7 row container}
 \usage{
-f7Row(..., gap = TRUE)
+f7Row(..., gap = TRUE, resizable = FALSE)
 }
 \arguments{
 \item{...}{Row content.}
 
 \item{gap}{Whether to display gap between columns. TRUE by default.}
+
+\item{resizable}{Whether to create a resizable row.}
 }
 \description{
 Build a Framework7 row container


### PR DESCRIPTION
Hi,

I added arguments to specify width of columns as well as create resizable columns and rows.

Example:

```r
library(shiny)

shiny::shinyApp(
  ui = f7Page(
    title = "Grid",
    f7SingleLayout(
     navbar = f7Navbar(title = "f7Row, f7Col"),
     f7Row(
     f7Col(
      resizable = TRUE,
      f7Card(
       "This is a simple card with plain text,
       but cards can also contain their own header,
       footer, list view, image, or any other element."
      )
     ),
     f7Col(
      resizable = TRUE,
      f7Card(
       title = "Card header",
       "This is a simple card with plain text,
        but cards can also contain their own header,
        footer, list view, image, or any other element.",
       footer = tagList(
        f7Button(color = "blue", label = "My button", src = "https://www.google.com"),
        f7Badge("Badge", color = "green")
       )
      )
     )
    )
    )
  ),
  server = function(input, output) {}
 )
}
```

Note that it's one or the other; specify size or resizable.