### PR TITLE
Added args to f7Popup() & rewrite bindings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ devices (iphone, samsung, htc, ...)
 on the user side but improves security and code quality
 
 ## Minor changes
+- new fullsize and closeButton parameter to `f7Popup()` + rewrite js binding. Thanks @pvictor
 - add extra parameters to `f7DatePicker()`: direction, openIn,
 scrollToInput, closeByOutsideClick, toolbar, toolbarCloseText,
 header and headerPlaceholder

--- a/R/f7Popup.R
+++ b/R/f7Popup.R
@@ -1,14 +1,25 @@
-#' Create a f7 popup
+#' @title Create a f7 popup
 #'
-#' @param ... Content.
+#' @description Popup is a popup window with any UI content that pops up over App's main content.
+#'  Popup as all other overlays is part of so called "Temporary Views".
+#'
+#' @param ... UI elements for the body of the popup window.
 #' @param id Popup unique id.
-#' @param title Title.
-#' @param backdrop Enables Popup backdrop (dark semi transparent layer behind). Default to TRUE.
-#' @param closeByBackdropClick When enabled, popup will be closed on backdrop click. Default to TRUE.
-#' @param closeOnEscape When enabled, popup will be closed on ESC keyboard key press. Default to FALSE.
-#' @param animate Whether the Popup should be opened/closed with animation or not. Default to TRUE.
-#' @param swipeToClose Whether the Popup can be closed with swipe gesture. Can be true to allow to close popup with swipes to top and to bottom.
-#' Default to FALSE.
+#' @param title Title for the popup window, use \code{NULL} for no title.
+#' @param backdrop Enables Popup backdrop (dark semi transparent layer behind).
+#'  Default to \code{TRUE}.
+#' @param closeByBackdropClick When enabled, popup will be closed on backdrop click.
+#'  Default to \code{TRUE}.
+#' @param closeOnEscape When enabled, popup will be closed on ESC keyboard key press.
+#'  Default to \code{FALSE}.
+#' @param animate Whether the Popup should be opened/closed with animation or not.
+#'  Default to \code{TRUE}.
+#' @param swipeToClose Whether the Popup can be closed with swipe gesture.
+#'  Can be true to allow to close popup with swipes to top and to bottom.
+#'  Default to \code{FALSE}.
+#' @param fullsize Open popup in full width or not. Default to \code{FALSE}.
+#' @param closeButton Add or not a button to easily close the popup.
+#'  Default to \code{TRUE}.
 #'
 #' @export
 #'
@@ -56,37 +67,58 @@
 #'    }
 #'  )
 #' }
-f7Popup <- function(..., id, title, backdrop = TRUE, closeByBackdropClick = TRUE,
-                    closeOnEscape = FALSE, animate = TRUE, swipeToClose = FALSE) {
+f7Popup <- function(..., id, title = NULL,
+                    backdrop = TRUE,
+                    closeByBackdropClick = TRUE,
+                    closeOnEscape = FALSE,
+                    animate = TRUE,
+                    swipeToClose = FALSE,
+                    fullsize = FALSE,
+                    closeButton = TRUE) {
 
-  popupProps <- dropNulls(
-    list(
-      class = "popup popup-tablet-fullscreen",
-      id = id,
-      style = "overflow-y: auto;",
-      `data-backdrop` = tolower(backdrop),
-      `data-close-by-backdrop-click` = tolower(closeByBackdropClick),
-      `data-close-on-escape` = tolower(closeOnEscape),
-      `data-animate` = tolower(animate),
-      `data-swipe-to-close` = tolower(swipeToClose)
-    )
+  config <- dropNulls(list(
+    backdrop = backdrop,
+    closeByBackdropClick = closeByBackdropClick,
+    closeOnEscape = closeOnEscape,
+    animate = animate,
+    swipeToClose = swipeToClose
+  ))
+
+  content <- shiny::tags$div(
+    class = "block",
+    if (!is.null(title)) shiny::tags$div(class = "block-title", title),
+    ...
   )
 
-  popupTag <- do.call(shiny::tags$div, popupProps)
-  popupWrap <- shiny::tagAppendChildren(
-    popupTag,
+  if (isTRUE(closeButton)) {
+    content <- htmltools::tagAppendChild(
+      content,
+      shiny::tags$a(
+        class = "link popup-close",
+        style = "position: absolute; top: -15px; right: 10px;",
+        href = "#",
+        f7Icon("close")
+      )
+    )
+  }
+
+  shiny::tags$div(
+    id = id,
+    class = "popup",
+    class = if (isTRUE(fullsize)) "popup-tablet-fullscreen",
+    style = "overflow-y: auto;",
     f7InputsDeps(),
-    shiny::br(),
-    shiny::br(),
-    shiny::div(
-      class = "block",
-      shiny::p(title),
-      shiny::p(shiny::a(class = "link popup-close", href = "#", "Close")),
-      shiny::p(...)
+    content,
+    shiny::tags$script(
+      type = "application/json",
+      `data-for` = id,
+      jsonlite::toJSON(
+        x = config,
+        auto_unbox = TRUE,
+        json_verbatim = TRUE
+      )
     )
   )
-
-  popupWrap
 }
 
 

--- a/docs/articles/Dark-Theme.html
+++ b/docs/articles/Dark-Theme.html
@@ -111,7 +111,7 @@
       <h1>Dark-Theme</h1>
                         <h4 class="author">David Granjon</h4>
             
-            <h4 class="date">2020-02-03</h4>
+            <h4 class="date">2020-02-11</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/RinteRface/shinyMobile/blob/master/vignettes/Dark-Theme.Rmd"><code>vignettes/Dark-Theme.Rmd</code></a></small>
       <div class="hidden name"><code>Dark-Theme.Rmd</code></div>

--- a/docs/articles/Gadgets.html
+++ b/docs/articles/Gadgets.html
@@ -111,7 +111,7 @@
       <h1>Gadgets</h1>
                         <h4 class="author">David Granjon</h4>
             
-            <h4 class="date">2020-02-03</h4>
+            <h4 class="date">2020-02-11</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/RinteRface/shinyMobile/blob/master/vignettes/Gadgets.Rmd"><code>vignettes/Gadgets.Rmd</code></a></small>
       <div class="hidden name"><code>Gadgets.Rmd</code></div>

--- a/docs/articles/Single-Layout.html
+++ b/docs/articles/Single-Layout.html
@@ -111,7 +111,7 @@
       <h1>Single-Layout</h1>
                         <h4 class="author">David Granjon</h4>
             
-            <h4 class="date">2020-02-03</h4>
+            <h4 class="date">2020-02-11</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/RinteRface/shinyMobile/blob/master/vignettes/Single-Layout.Rmd"><code>vignettes/Single-Layout.Rmd</code></a></small>
       <div class="hidden name"><code>Single-Layout.Rmd</code></div>

--- a/docs/articles/Split-Layout.html
+++ b/docs/articles/Split-Layout.html
@@ -111,7 +111,7 @@
       <h1>Split-Layout</h1>
                         <h4 class="author">David Granjon</h4>
             
-            <h4 class="date">2020-02-03</h4>
+            <h4 class="date">2020-02-11</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/RinteRface/shinyMobile/blob/master/vignettes/Split-Layout.Rmd"><code>vignettes/Split-Layout.Rmd</code></a></small>
       <div class="hidden name"><code>Split-Layout.Rmd</code></div>

--- a/docs/articles/Tabs-Layout.html
+++ b/docs/articles/Tabs-Layout.html
@@ -111,7 +111,7 @@
       <h1>Tabs-Layout</h1>
                         <h4 class="author">David Granjon</h4>
             
-            <h4 class="date">2020-02-03</h4>
+            <h4 class="date">2020-02-11</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/RinteRface/shinyMobile/blob/master/vignettes/Tabs-Layout.Rmd"><code>vignettes/Tabs-Layout.Rmd</code></a></small>
       <div class="hidden name"><code>Tabs-Layout.Rmd</code></div>

--- a/docs/articles/getting-started.html
+++ b/docs/articles/getting-started.html
@@ -111,7 +111,7 @@
       <h1>Getting Started</h1>
                         <h4 class="author">David Granjon</h4>
             
-            <h4 class="date">2020-02-03</h4>
+            <h4 class="date">2020-02-11</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/RinteRface/shinyMobile/blob/master/vignettes/getting-started.Rmd"><code>vignettes/getting-started.Rmd</code></a></small>
       <div class="hidden name"><code>getting-started.Rmd</code></div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -190,6 +190,7 @@
 <h2 class="hasAnchor">
 <a href="#minor-changes" class="anchor"></a>Minor changes</h2>
 <ul>
+<li>new fullsize and closeButton parameter to <code><a href="../reference/f7Popup.html">f7Popup()</a></code> + rewrite js binding. Thanks <a href='https://github.com/pvictor'>@pvictor</a></li>
 <li>add extra parameters to <code><a href="../reference/f7DatePicker.html">f7DatePicker()</a></code>: direction, openIn, scrollToInput, closeByOutsideClick, toolbar, toolbarCloseText, header and headerPlaceholder</li>
 <li>add new parameters to <code><a href="../reference/updateF7Gauge.html">updateF7Gauge()</a></code>. Thanks <a href='https://github.com/rodrigoheck'>@rodrigoheck</a> for the suggestion</li>
 <li>add noSwipping argument to <code><a href="../reference/f7Slider.html">f7Slider()</a></code> to prevent wrong behaviour when used in <code><a href="../reference/f7TabLayout.html">f7TabLayout()</a></code>

--- a/docs/reference/f7Popup.html
+++ b/docs/reference/f7Popup.html
@@ -45,7 +45,8 @@
   
 
 <meta property="og:title" content="Create a f7 popup — f7Popup" />
-<meta property="og:description" content="Create a f7 popup" />
+<meta property="og:description" content="Popup is a popup window with any UI content that pops up over App's main content.
+ Popup as all other overlays is part of so called &quot;Temporary Views&quot;." />
 <meta property="og:image" content="/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -154,18 +155,21 @@
     </div>
 
     <div class="ref-description">
-    <p>Create a f7 popup</p>
+    <p>Popup is a popup window with any UI content that pops up over App's main content.
+ Popup as all other overlays is part of so called "Temporary Views".</p>
     </div>
 
     <pre class="usage"><span class='fu'>f7Popup</span>(
   <span class='no'>...</span>,
   <span class='no'>id</span>,
-  <span class='no'>title</span>,
+  <span class='kw'>title</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>backdrop</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>closeByBackdropClick</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>closeOnEscape</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>animate</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
-  <span class='kw'>swipeToClose</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
+  <span class='kw'>swipeToClose</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>fullsize</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>closeButton</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>
 )</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -173,7 +177,7 @@
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>...</th>
-      <td><p>Content.</p></td>
+      <td><p>UI elements for the body of the popup window.</p></td>
     </tr>
     <tr>
       <th>id</th>
@@ -181,28 +185,42 @@
     </tr>
     <tr>
       <th>title</th>
-      <td><p>Title.</p></td>
+      <td><p>Title for the popup window, use <code>NULL</code> for no title.</p></td>
     </tr>
     <tr>
       <th>backdrop</th>
-      <td><p>Enables Popup backdrop (dark semi transparent layer behind). Default to TRUE.</p></td>
+      <td><p>Enables Popup backdrop (dark semi transparent layer behind).
+Default to <code>TRUE</code>.</p></td>
     </tr>
     <tr>
       <th>closeByBackdropClick</th>
-      <td><p>When enabled, popup will be closed on backdrop click. Default to TRUE.</p></td>
+      <td><p>When enabled, popup will be closed on backdrop click.
+Default to <code>TRUE</code>.</p></td>
     </tr>
     <tr>
       <th>closeOnEscape</th>
-      <td><p>When enabled, popup will be closed on ESC keyboard key press. Default to FALSE.</p></td>
+      <td><p>When enabled, popup will be closed on ESC keyboard key press.
+Default to <code>FALSE</code>.</p></td>
     </tr>
     <tr>
       <th>animate</th>
-      <td><p>Whether the Popup should be opened/closed with animation or not. Default to TRUE.</p></td>
+      <td><p>Whether the Popup should be opened/closed with animation or not.
+Default to <code>TRUE</code>.</p></td>
     </tr>
     <tr>
       <th>swipeToClose</th>
-      <td><p>Whether the Popup can be closed with swipe gesture. Can be true to allow to close popup with swipes to top and to bottom.
-Default to FALSE.</p></td>
+      <td><p>Whether the Popup can be closed with swipe gesture.
+Can be true to allow to close popup with swipes to top and to bottom.
+Default to <code>FALSE</code>.</p></td>
+    </tr>
+    <tr>
+      <th>fullsize</th>
+      <td><p>Open popup in full width or not. Default to <code>FALSE</code>.</p></td>
+    </tr>
+    <tr>
+      <th>closeButton</th>
+      <td><p>Add or not a button to easily close the popup.
+Default to <code>TRUE</code>.</p></td>
     </tr>
     </table>
 

--- a/inst/framework7-5.3.0/input-bindings/popupInputBinding.js
+++ b/inst/framework7-5.3.0/input-bindings/popupInputBinding.js
@@ -5,33 +5,19 @@ $.extend(f7PopupBinding, {
 
   initialize: function(el) {
 
-    // recover the inputId passed in the R function
-    var id = $(el).attr("id");
-
-    var data = {};
-    [].forEach.call(el.attributes, function(attr) {
-      if (/^data-/.test(attr.name)) {
-        var camelCaseName = attr.name.substr(5).replace(/-(.)/g, function ($0, $1) {
-          return $1.toUpperCase();
-        });
-        // convert "true" to true and "false" to false
-        var isTrueSet = (attr.value == "true");
-        data[camelCaseName] = isTrueSet;
-      }
-    });
-
-    // add the id
-    data.el = '#' + id;
+    var config = $(el).find("script[data-for='" + el.id + "']");
+    config = JSON.parse(config.html());
+    config.el = el;
 
     // this is to show shiny outputs in the popup
-    data.on = {
+    config.on = {
       opened: function () {
         $(el).trigger('shown');
       }
     };
 
     // feed the create method
-    var p = app.popup.create(data);
+    var p = app.popup.create(config);
 
   },
 

--- a/man/f7Popup.Rd
+++ b/man/f7Popup.Rd
@@ -7,34 +7,47 @@
 f7Popup(
   ...,
   id,
-  title,
+  title = NULL,
   backdrop = TRUE,
   closeByBackdropClick = TRUE,
   closeOnEscape = FALSE,
   animate = TRUE,
-  swipeToClose = FALSE
+  swipeToClose = FALSE,
+  fullsize = FALSE,
+  closeButton = TRUE
 )
 }
 \arguments{
-\item{...}{Content.}
+\item{...}{UI elements for the body of the popup window.}
 
 \item{id}{Popup unique id.}
 
-\item{title}{Title.}
+\item{title}{Title for the popup window, use \code{NULL} for no title.}
 
-\item{backdrop}{Enables Popup backdrop (dark semi transparent layer behind). Default to TRUE.}
+\item{backdrop}{Enables Popup backdrop (dark semi transparent layer behind).
+Default to \code{TRUE}.}
 
-\item{closeByBackdropClick}{When enabled, popup will be closed on backdrop click. Default to TRUE.}
+\item{closeByBackdropClick}{When enabled, popup will be closed on backdrop click.
+Default to \code{TRUE}.}
 
-\item{closeOnEscape}{When enabled, popup will be closed on ESC keyboard key press. Default to FALSE.}
+\item{closeOnEscape}{When enabled, popup will be closed on ESC keyboard key press.
+Default to \code{FALSE}.}
 
-\item{animate}{Whether the Popup should be opened/closed with animation or not. Default to TRUE.}
+\item{animate}{Whether the Popup should be opened/closed with animation or not.
+Default to \code{TRUE}.}
 
-\item{swipeToClose}{Whether the Popup can be closed with swipe gesture. Can be true to allow to close popup with swipes to top and to bottom.
-Default to FALSE.}
+\item{swipeToClose}{Whether the Popup can be closed with swipe gesture.
+Can be true to allow to close popup with swipes to top and to bottom.
+Default to \code{FALSE}.}
+
+\item{fullsize}{Open popup in full width or not. Default to \code{FALSE}.}
+
+\item{closeButton}{Add or not a button to easily close the popup.
+Default to \code{TRUE}.}
 }
 \description{
-Create a f7 popup
+Popup is a popup window with any UI content that pops up over App's main content.
+ Popup as all other overlays is part of so called "Temporary Views".
 }
 \examples{
 if (interactive()) {


### PR DESCRIPTION
Hello David,

Two new arguments in `f7Popup()` :
* `fullsize` : open the popup fullsize or not (not fullsize works on desktop and tablet)
* `closeButton` : add or not a button to close popup, I use a `f7Icon` as symbol and modify position of the button.

Also updated JS bindings.

On desktop, looks like this : 

![image](https://user-images.githubusercontent.com/4415580/74100034-8167e200-4b2a-11ea-845d-715c917de1c8.png)

On mobile, always display in full screen : 

![image](https://user-images.githubusercontent.com/4415580/74100041-a3f9fb00-4b2a-11ea-9d6b-da4faba853c3.png)

Victor
