### PR TITLE
Fixed conflict between new and old icons

### DIFF
--- a/R/f7Icon.R
+++ b/R/f7Icon.R
@@ -69,7 +69,11 @@ f7Icon <- function(..., lib = NULL, color = NULL, style = NULL, old = TRUE) {
   }
   if (!is.null(lib)) {
     if (identical(lib, "ios")) {
-      iconCl <- "icon f7-icons ios-only"
+      if (isTRUE(old)) {
+        iconCl <- "icon f7-icons-old ios-only"
+      } else {
+        iconCl <- "icon f7-icons ios-only"
+      }
     }
     if (identical(lib, "md")) {
       iconCl <- "icon material-icons md-only"
@@ -77,7 +81,11 @@ f7Icon <- function(..., lib = NULL, color = NULL, style = NULL, old = TRUE) {
   } else {
     # class icon is necessary so that icons with labels render well,
     # for instance
-    iconCl <- "icon f7-icons"
+    if (isTRUE(old)) {
+      iconCl <- "icon f7-icons-old"
+    } else {
+      iconCl <- "icon f7-icons"
+    }
   }
 
   if (!is.null(color)) {

--- a/R/f7Popup.R
+++ b/R/f7Popup.R
@@ -97,7 +97,7 @@ f7Popup <- function(..., id, title = NULL,
         class = "link popup-close",
         style = "position: absolute; top: -15px; right: 10px;",
         href = "#",
-        f7Icon("close")
+        f7Icon("multiply", old = FALSE)
       )
     )
   }

--- a/inst/framework7-5.3.0/f7-icons-old/css/framework7-icons.css
+++ b/inst/framework7-5.3.0/f7-icons-old/css/framework7-icons.css
@@ -1,17 +1,17 @@
 @font-face {
-  font-family: 'Framework7 Icons';
+  font-family: 'Framework7 Icons Old';
   font-style: normal;
   font-weight: 400;
   src: url("../fonts/Framework7Icons-Regular.eot");
   src: local('Framework7 Icons'),
-     local('Framework7Icons-Regular'),
-     url("../fonts/Framework7Icons-Regular.woff2") format("woff2"),
-     url("../fonts/Framework7Icons-Regular.woff") format("woff"),
-     url("../fonts/Framework7Icons-Regular.ttf") format("truetype");
+    local('Framework7Icons-Regular'),
+    url("../fonts/Framework7Icons-Regular.woff2") format("woff2"),
+    url("../fonts/Framework7Icons-Regular.woff") format("woff"),
+    url("../fonts/Framework7Icons-Regular.ttf") format("truetype");
 }
 
-.f7-icons, .framework7-icons {
-  font-family: 'Framework7 Icons';
+.f7-icons-old, .framework7-icons {
+  font-family: 'Framework7 Icons Old';
   font-weight: normal;
   font-style: normal;
   font-size: 28px;


### PR DESCRIPTION
Hello David,

There was a bug when using old and new icons at the same time. Now it works ;)

```r
library(shiny)
library(shinyMobile)
ui <- f7Page(
  f7Icon("plus", old = FALSE),
  f7Icon("plus"),
  f7Icon("close", old = TRUE),
  f7Icon("multiply", old = FALSE),
  "bla"
)
server <- function(input, output, session) {
}
shinyApp(ui, server)
```

Also changed the icon used in `f7Popup` for a new one.

Victor