### PR TITLE
Add I() to updateF7AutoComplete()

### DIFF
--- a/R/f7-update-inputs.R
+++ b/R/f7-update-inputs.R
@@ -928,7 +928,7 @@ updateF7AutoComplete <- function(inputId, value =  NULL,
                                  session = shiny::getDefaultReactiveDomain()) {
   message <- dropNulls(
     list(
-      value = value
+      value = I(value)
     )
   )
   session$sendInputMessage(inputId, message)


### PR DESCRIPTION
This helps force value to be a one element JS array - which prevents single-element value updates from being converted to a character array.