### PR TITLE
named lists in f7Select() + width

### DIFF
--- a/man/f7Select.Rd
+++ b/man/f7Select.Rd
@@ -4,7 +4,7 @@
 \alias{f7Select}
 \title{Create an f7 select input}
 \usage{
-f7Select(inputId, label, choices, selected = NULL)
+f7Select(inputId, label, choices, selected = NULL, width = NULL)
 }
 \arguments{
 \item{inputId}{Select input id.}


### PR DESCRIPTION
Hey David,

Small PR to support named lists in `f7Select()` like in `shiny::selectInput()`.
And added width argument to be similar as `shiny::selectInput()`.


Victor