### PR TITLE
Fix order of arguments in htmltools::attachDependencies()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shinyMobile
 Type: Package
 Title: Mobile Ready 'shiny' Apps with Standalone Capabilities
-Version: 0.7.0
+Version: 0.7.1
 Authors@R: c(
   person("David", "Granjon", email = "dgranjon@ymail.com", role = c("aut", "cre")),
   person("Victor", "Perrier", email = "info@dreamrs.fr", role = "aut"),
@@ -23,7 +23,7 @@ Encoding: UTF-8
 URL: https://github.com/RinteRface/shinyMobile, https://rinterface.github.io/shinyMobile/
 BugReports: https://github.com/RinteRface/shinyMobile/issues
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests: 
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# shinyMobile 0.7.1
+
+Patch release correcting an internal use of htmltools::attachDependencies().
+
 # shinyMobile 0.7.0
 
 ## Notes

--- a/R/preview_mobile.R
+++ b/R/preview_mobile.R
@@ -119,8 +119,8 @@ create_app_ui <- function(iframe, device, color, landscape) {
 
   shiny::fluidPage(
     htmltools::attachDependencies(
-      devices_css_deps,
-      shiny::br()
+      shiny::br(),
+      devices_css_deps
     ),
     # container for preview app
     shiny::br(),

--- a/man/f7Fab.Rd
+++ b/man/f7Fab.Rd
@@ -13,7 +13,7 @@ f7Fab(inputId, label, width = NULL, ..., flag = NULL)
 you could also use any other HTML, like an image.}
 
 \item{width}{The width of the input, e.g. \code{'400px'}, or \code{'100\%'};
-see \code{\link[shiny:validateCssUnit]{validateCssUnit()}}.}
+see \code{\link[shiny:reexports]{validateCssUnit()}}.}
 
 \item{...}{Named attributes to be applied to the button or link.}
 


### PR DESCRIPTION
This PR fixes the following failure in the current CRAN version of shinyMobile (0.7) with the new version of htmltools (0.5.1):

```
> library(testthat)
> library(shinyMobile)
> 
> test_check("shinyMobile")
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-preview_mobile.R:17:3): dependencies ────────────────────────────
Error: Could not coerce object of class 'list' into a list of HTML dependencies
Backtrace:
     █
  1. └─shinyMobile:::create_app_ui(...) test-preview_mobile.R:17:2
  2.   ├─shiny::fluidPage(...)
  3.   │ ├─shiny::bootstrapPage(...)
  4.   │ │ ├─htmltools::attachDependencies(...)
  5.   │ │ └─htmltools::tagList(...)
  6.   │ │   └─rlang::dots_list(...)
  7.   │ └─htmltools::div(class = "container-fluid", ...)
  8.   │   └─rlang::dots_list(...)
  9.   └─htmltools::attachDependencies(devices_css_deps, shiny::br())
 10.     └─htmltools:::asDependencies(value)

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 71 ]
Error: Test failures
Execution halted

1 error ✖ | 0 warnings ✔ | 0 notes ✔
```

Please consider sending this as patch release to CRAN asap.