### PR TITLE
Included navbar under @examples

### DIFF
--- a/R/f7-tables.R
+++ b/R/f7-tables.R
@@ -14,6 +14,9 @@
 #'   ui = f7Page(
 #'     title = "My app",
 #'     f7SingleLayout(
+#'        navbar = f7Navbar(
+#'          title = "Single Layout",
+#'        ),
 #'       uiOutput("table")
 #'     )
 #'   ),


### PR DESCRIPTION
The R example had a navbar statement missing