### PR TITLE
Adjust test to only check for added dependency

### DIFF
--- a/tests/testthat/test-preview_mobile.R
+++ b/tests/testthat/test-preview_mobile.R
@@ -22,7 +22,7 @@ test_that("dependencies", {
   deps_names <- vapply(deps, `[[`, "name", FUN.VALUE = character(1))
   idx <- which(deps_names == "marvel-devices-css")
 
-  expect_length(deps, 2)
+  expect_length(idx, 1)
   expect_equal(deps[[idx]]$name, "marvel-devices-css")
   expect_equal(deps[[idx]]$version, "1.0.0")
   expect_equal(deps[[idx]]$stylesheet, "devices.min.css")


### PR DESCRIPTION
...not test the number of all dependencies found.

-----------------------------

Shiny is changing the number of dependencies being returned. This test breaks when the new version of Shiny is being reverse dependency checked by CRAN.

Once merged, is it possible to release `shinyMobile` to CRAN? (This PR is a blocker for the release of the new version of Shiny.) Please let me know if I can help in the release process. 

Thank you!
Barret