### PR TITLE
Fix Typo on f7File

### DIFF
--- a/R/f7-upload.R
+++ b/R/f7-upload.R
@@ -66,7 +66,7 @@ f7File <- function(inputId, label, multiple = FALSE, accept = NULL, width = NULL
       shiny::tags$label(
         class = "input-group-btn",
         shiny::span(
-          class = "bustton button-fill btn-file",
+          class = "button button-fill btn-file",
           buttonLabel,
           inputTag
         )


### PR DESCRIPTION
Change `bustton` for `button` in the f7File class to get it to display properly